### PR TITLE
install dotnet 6

### DIFF
--- a/.devcontainer/on-create.sh
+++ b/.devcontainer/on-create.sh
@@ -79,6 +79,9 @@ gh completion -s zsh > ~/.oh-my-zsh/completions/_gh
 kubectl completion zsh > "$HOME/.oh-my-zsh/completions/_kubectl"
 k3d completion zsh > "$HOME/.oh-my-zsh/completions/_k3d"
 
+echo "installing dotnet 6"
+sudo apt-get install -y dotnet-sdk-6.0
+
 echo "create local registry"
 docker network create k3d
 k3d registry create registry.localhost --port 5500

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ This repo walks through the rich end-to-end developer experience in a series of 
   - A [free Azure subscription](https://azure.microsoft.com/en-in/free/) will work for exploration
   - Some advanced scenarios also require AAD permissions
 
+## Notes
+
+- The base Codespaces images recently updated to dotnet core 7
+- PiB currently uses dotnet core 6
+- Both dotnet core 6 and 7 are installed in the Codespaces image as we migrate to dotnet 7
+
 ## GitHub Codespaces
 
 > Codespaces allows you to develop in a secure, configurable, and dedicated development environment in the cloud that works how and where you want it to


### PR DESCRIPTION
# Purpose of PR

- the base images recently updated to dotnet 7
- install dotnet 6 as we migrate to dotnet 7

## Type of PR

- [x] Documentation changes
- [ ] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes
- [x] Codespaces changes
